### PR TITLE
implement fwaasv2 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.1.0
+	github.com/gophercloud/gophercloud => github.com/c445/gophercloud v0.12.1-0.20200930110044-591085065187
 	k8s.io/api => k8s.io/api v0.18.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.18.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.18.4

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/c445/gophercloud v0.12.1-0.20200930110044-591085065187 h1:X4vU+5nICjNW4OKJ3Jg2qd73zLMYkYt/ZeX+Lgiz0ZU=
+github.com/c445/gophercloud v0.12.1-0.20200930110044-591085065187/go.mod h1:VX0Ibx85B60B5XOrZr6kaNwrmPUzcmMpwxvQ1WQIIWM=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -129,9 +131,6 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.1.0 h1:rVsPeBmXbYv4If/cumu1AzZPwV58q433hvONV1UEZoI=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gophercloud/gophercloud v0.12.0 h1:mZrie07npp6ODiwHZolTicr5jV8Ogn43AvAsSMm6Ork=
-github.com/gophercloud/gophercloud v0.12.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c h1:7lF+Vz0LqiRidnzC1Oq86fpX1q/iEv2KJdrCtttYjT4=
 github.com/gopherjs/gopherjs v0.0.0-20190430165422-3e4dfb77656c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -191,6 +190,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -340,7 +341,6 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -376,7 +376,6 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -400,7 +399,6 @@ golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -442,7 +440,6 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -504,7 +501,6 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/daimler/kosmoo/pkg/metrics"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/prometheus/client_golang/prometheus"
@@ -257,6 +256,11 @@ func updateMetrics(provider *gophercloud.ProviderClient, eo gophercloud.Endpoint
 		}
 
 		if err := metrics.PublishFirewallV1Metrics(neutronClient, tenantID); err != nil {
+			err := logError("scraping firewall v1 metrics failed: %v", err)
+			errs = append(errs, err)
+		}
+
+		if err := metrics.PublishFirewallV2Metrics(neutronClient, tenantID); err != nil {
 			err := logError("scraping firewall v1 metrics failed: %v", err)
 			errs = append(errs, err)
 		}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/ini.v1"
@@ -257,17 +256,9 @@ func updateMetrics(provider *gophercloud.ProviderClient, eo gophercloud.Endpoint
 			errs = append(errs, err)
 		}
 
-		// check if Neutron is using FWaaS v1
-		// if FWaaS v2 is enabled, the extension alias is fwaas_v2 (the directories are the extension names)
-		// https://godoc.org/github.com/gophercloud/gophercloud/acceptance/openstack/networking/v2/extensions
-		fwaasV1Extension := extensions.Get(neutronClient, "fwaas")
-		if fwaasV1Extension.Body != nil {
-			if err := metrics.PublishFirewallMetrics(neutronClient, tenantID); err != nil {
-				err := logError("scraping firewall metrics failed: %v", err)
-				errs = append(errs, err)
-			}
-		} else {
-			klog.Info("skipping Firewall metrics as FWaaS v1 is not enabled")
+		if err := metrics.PublishFirewallV1Metrics(neutronClient, tenantID); err != nil {
+			err := logError("scraping firewall v1 metrics failed: %v", err)
+			errs = append(errs, err)
 		}
 	}
 

--- a/pkg/metrics/fwaasv2.go
+++ b/pkg/metrics/fwaasv2.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+
+package metrics
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas_v2/groups"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
+)
+
+var (
+	firewallV2GroupAdminStateUp *prometheus.GaugeVec
+	firewallV2GroupStatus       *prometheus.GaugeVec
+
+	// according to the nl_constants from https://github.com/openstack/neutron-fwaas/blob/stable/ocata/neutron_fwaas/services/firewall/fwaas_plugin.py
+	// we will get the following firewall states
+	firewallV2States = []string{"ACTIVE", "DOWN", "ERROR", "INACTIVE", "PENDING_CREATE", "PENDING_DELETE", "PENDING_UPDATE"}
+
+	firewallV2Labels = []string{"id", "name", "description", "ingressPolicyID", "egressPolicyID", "projectID"}
+)
+
+func registerFWaaSV2Metrics() {
+	firewallV2GroupAdminStateUp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: generateName("firewall_v2_group_admin_state_up"),
+			Help: "Firewall v2 status",
+		},
+		firewallV2Labels,
+	)
+	firewallV2GroupStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: generateName("firewall_v2_group_status"),
+			Help: "Firewall v2 status",
+		},
+		append(firewallV2Labels, "status"),
+	)
+
+	prometheus.MustRegister(firewallV2GroupAdminStateUp)
+	prometheus.MustRegister(firewallV2GroupStatus)
+}
+
+// PublishFirewallV1Metrics makes the list request to the firewall api and
+// passes the result to a publish function. It only does that when the extension
+// is available in neutron.
+func PublishFirewallV2Metrics(client *gophercloud.ServiceClient, tenantID string) error {
+	// check if Neutron extenstion FWaaS v1 is available.
+	fwaasV1Extension := extensions.Get(client, "fwaas_v2")
+	if fwaasV1Extension.Body != nil {
+		return publishFirewallV2Metrics(client, tenantID)
+	}
+
+	// reset metrics if fwaas v1 is not available to not publish them anymore
+	resetFirewallV2Metrics()
+	klog.Info("skipping Firewall metrics as FWaaS v1 is not enabled")
+	return nil
+}
+
+func publishFirewallV2Metrics(client *gophercloud.ServiceClient, tenantID string) error {
+	// first step: gather the data
+	mc := newOpenStackMetric("firewallv2_group", "list")
+	pages, err := groups.List(client, groups.ListOpts{}).AllPages()
+	if mc.Observe(err) != nil {
+		// only warn, maybe the next list will work.
+		klog.Warningf("Unable to list firewall groups: %v", err)
+		return err
+	}
+	groupsList, err := groups.ExtractGroups(pages)
+	if err != nil {
+		// only warn, maybe the next publish will work.
+		klog.Warningf("Unable to extract firewall groups: %v", err)
+		return err
+	}
+
+	// second step: reset the old metrics
+	resetFirewallV2Metrics()
+
+	// third step: publish the metrics
+	for _, group := range groupsList {
+		if group.Name == "default" {
+			continue
+		}
+		publishFirewallV2GroupMetric(group)
+	}
+
+	return nil
+}
+
+// resetFirewallV2Metrics resets the firewall v1 metrics
+func resetFirewallV2Metrics() {
+	firewallV2GroupAdminStateUp.Reset()
+	firewallV2GroupStatus.Reset()
+}
+
+// publishFirewallV2GroupMetric extracts data from a firewall and exposes the metrics via prometheus
+func publishFirewallV2GroupMetric(group groups.Group) {
+	labels := []string{group.ID, group.Name, group.Description, group.IngressFirewallPolicyID, group.EgressFirewallPolicyID, group.ProjectID}
+	firewallV2GroupAdminStateUp.WithLabelValues(labels...).Set(boolFloat64(group.AdminStateUp))
+
+	// create one metric per status
+	for _, state := range firewallV2States {
+		stateLabels := append(labels, state)
+		firewallV2GroupStatus.WithLabelValues(stateLabels...).Set(boolFloat64(group.Status == state))
+	}
+}

--- a/pkg/metrics/fwaasv2.go
+++ b/pkg/metrics/fwaasv2.go
@@ -41,19 +41,19 @@ func registerFWaaSV2Metrics() {
 	prometheus.MustRegister(firewallV2GroupStatus)
 }
 
-// PublishFirewallV1Metrics makes the list request to the firewall api and
+// PublishFirewallV2Metrics makes the list request to the firewall api and
 // passes the result to a publish function. It only does that when the extension
 // is available in neutron.
 func PublishFirewallV2Metrics(client *gophercloud.ServiceClient, tenantID string) error {
-	// check if Neutron extenstion FWaaS v1 is available.
-	fwaasV1Extension := extensions.Get(client, "fwaas_v2")
-	if fwaasV1Extension.Body != nil {
+	// check if Neutron extenstion FWaaS v2 is available.
+	fwaasV2Extension := extensions.Get(client, "fwaas_v2")
+	if fwaasV2Extension.Body != nil {
 		return publishFirewallV2Metrics(client, tenantID)
 	}
 
-	// reset metrics if fwaas v1 is not available to not publish them anymore
+	// reset metrics if fwaas v2 is not available to not publish them anymore
 	resetFirewallV2Metrics()
-	klog.Info("skipping Firewall metrics as FWaaS v1 is not enabled")
+	klog.Info("skipping Firewall metrics as FWaaS v2 is not enabled")
 	return nil
 }
 
@@ -87,7 +87,7 @@ func publishFirewallV2Metrics(client *gophercloud.ServiceClient, tenantID string
 	return nil
 }
 
-// resetFirewallV2Metrics resets the firewall v1 metrics
+// resetFirewallV2Metrics resets the firewall v2 metrics
 func resetFirewallV2Metrics() {
 	firewallV2GroupAdminStateUp.Reset()
 	firewallV2GroupStatus.Reset()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,7 @@ func RegisterMetrics(prefix string) {
 	registerLoadBalancerMetrics()
 	registerOpenStackMetrics()
 	registerFWaaSV1Metrics()
+	registerFWaaSV2Metrics()
 	registerServerMetrics()
 }
 


### PR DESCRIPTION
* use gophercloud fork for fwaasv2 support
* Refactors `pkg/metrics/fwaasv1.go` to name v1
* Implements `pkg/metrics/fwaasv2.go` to scrape fwaasv2 firewall groups