### PR TITLE
expose listener metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ func updateMetrics(provider *gophercloud.ProviderClient, eo gophercloud.Endpoint
 		}
 
 		if err := metrics.PublishFirewallV2Metrics(neutronClient, tenantID); err != nil {
-			err := logError("scraping firewall v1 metrics failed: %v", err)
+			err := logError("scraping firewall v2 metrics failed: %v", err)
 			errs = append(errs, err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -252,6 +252,11 @@ func updateMetrics(provider *gophercloud.ProviderClient, eo gophercloud.Endpoint
 			errs = append(errs, err)
 		}
 
+		if err := metrics.PublishListenerMetrics(loadbalancerClient, tenantID); err != nil {
+			err := logError("scraping listener metrics failed: %v", err)
+			errs = append(errs, err)
+		}
+
 		if err := metrics.PublishServerMetrics(computeClient, tenantID); err != nil {
 			err := logError("scraping server metrics failed: %v", err)
 			errs = append(errs, err)


### PR DESCRIPTION
this pr exposes the listener metrics: id, name, port, protocol and the assigned loadbalancer_id

```
# HELP kos_listener_status Listener status
# TYPE kos_listener_status gauge
kos_listener_status{id="0",loadbalancer_id="1",name="k8s-clusterapi-cluster-kubeapi-6443",port="TCP",protocol="6443",status="ACTIVE"} 1
kos_listener_status{id="0",loadbalancer_id="1",name="k8s-clusterapi-cluster-kubeapi-6443",port="TCP",protocol="6443",status="ERROR"} 0
kos_listener_status{id="0",loadbalancer_id="1",name="k8s-clusterapi-cluster-kubeapi-6443",port="TCP",protocol="6443",status="PENDING_CREATE"} 0
kos_listener_status{id="0",loadbalancer_id="1",name="k8s-clusterapi-cluster-kubeapi-6443",port="TCP",protocol="6443",status="PENDING_DELETE"} 0
kos_listener_status{id="0",loadbalancer_id="1",name="k8s-clusterapi-cluster-kubeapi-6443",port="TCP",protocol="6443",status="PENDING_UPDATE"} 0
```

----
Georg Schreiber, <georg.g.schreiber@mercedes-benz.com>, 
Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)